### PR TITLE
[~] Cleaned up configurations

### DIFF
--- a/rubocop-rspec.yml
+++ b/rubocop-rspec.yml
@@ -10,8 +10,5 @@ RSpec/ContextWording:
 RSpec/AnyInstance:
   Enabled: false
 
-RSpec/PredicateMatcher:
-  Strict: true
-
 RSpec/MessageSpies:
   Enabled: false

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -18,9 +18,6 @@ Style/Lambda:
 Style/LambdaCall:
   EnforcedStyle: braces
 
-Style/ClassAndModuleChildren:
-  EnforcedStyle: nested
-
 # can I remove?
 Style/BlockComments:
   Enabled: false
@@ -43,16 +40,11 @@ Style/Semicolon:
 Style/NumericPredicate:
   Enabled: false
 
-Layout/IndentationWidth:
-  Enabled: true
-
-Layout/EmptyLinesAroundAccessModifier:
-  EnforcedStyle: around
-
 Layout/MultilineMethodCallIndentation:
   EnforcedStyle: indented
 
 Layout/MultilineAssignmentLayout:
+  Enabled: true
   EnforcedStyle: same_line
 
 Layout/IndentationConsistency:
@@ -76,9 +68,6 @@ Layout/ArgumentAlignment:
 
 Layout/FirstArrayElementIndentation:
   EnforcedStyle: consistent
-
-Layout/LineLength:
-  Max: 120
 
 Metrics/ClassLength:
   Exclude:


### PR DESCRIPTION
obs.: On initial commit, I simply copied over sts' rubocop.yml, moved RSpec cops into `rubocop-rspec.yml` and removed a `rubocop-require_tools` cop from it.

## Work done so far:
* Enabled `Layout/MultilineAssignmentLayout` (it had custom settings but it is disabled by default)
* Removed redundant custom settings (i.e. same as default):
```
# rubocop.yml
{"Style/ClassAndModuleChildren"=>{"EnforcedStyle"=>"nested"},
 "Layout/IndentationWidth"=>{"Enabled"=>true},
 "Layout/EmptyLinesAroundAccessModifier"=>{"EnforcedStyle"=>"around"},
 "Layout/LineLength"=>{"Max"=>120}}

# rubocop-rspec.yml
{"RSpec/PredicateMatcher"=>{"Strict"=>true}}
```