### PR TITLE
[~] Remove Style/Semicolon custom configuration

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -32,10 +32,6 @@ Style/IfUnlessModifier:
 Style/ParallelAssignment:
   Enabled: false
 
-# can we talk about it?
-Style/Semicolon:
-  AllowAsExpressionSeparator: true
-
 # can I remove it?
 Style/NumericPredicate:
   Enabled: false


### PR DESCRIPTION
Removed after talk with @ybregey 

Removing the custom configuration will result in falling back to the default one (`AllowAsExpressionSeparator: false`). See [here](https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/LineLength).