### PR TITLE
[~] tune rubocop

### DIFF
--- a/rubocop-rspec.yml
+++ b/rubocop-rspec.yml
@@ -12,3 +12,9 @@ RSpec/AnyInstance:
 
 RSpec/MessageSpies:
   Enabled: false
+
+RSpec/EmptyExampleGroup:
+  Enabled: true
+  Exclude:
+    - "spec/requests/**/*.rb"
+

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -88,3 +88,6 @@ Lint/AssignmentInCondition:
 
 Lint/UnderscorePrefixedVariableName:
   AllowKeywordBlockArguments: true
+
+Lint/EndAlignment:
+  EnforcedStyleAlignWith: variable


### PR DESCRIPTION
# what the pr does?
1. request tests have empty examples due to rswag DSL.
that why I disabled ```EmptyExampleGroup``` cop for everything what we have in spec/requests directory.
2. changed EndAlignment to ```variable``` which is kinda convention what we had on STS
```ruby
# bad
variable = if true
    end

# good
variable = if true
end

variable =
  if true
  end

```