### PR TITLE
[~] rspec for request tests

### DIFF
--- a/rubocop-rspec.yml
+++ b/rubocop-rspec.yml
@@ -13,8 +13,7 @@ RSpec/AnyInstance:
 RSpec/MessageSpies:
   Enabled: false
 
-RSpec/EmptyExampleGroup:
+RSpec:
   Enabled: true
   Exclude:
     - "spec/requests/**/*.rb"
-


### PR DESCRIPTION
# what the PR does?
rswag DSL does not follow some RSpec cops by default, so the PR disables two of them:
```ruby
spec/requests/api/v3/internal/rmo_clients_spec.rb:5:1: C: RSpec/MultipleMemoizedHelpers: Example group has too many memoized helpers [6/5]                                                                                                  
RSpec.describe "Api::V3::Internal::RmoClients", type: :request, swagger_doc: "api/v3/internal/swagger.json" do ...                                                                                                                          
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                              
spec/requests/api/v3/internal/shipment_segments_spec.rb:5:1: C: RSpec/MultipleMemoizedHelpers: Example group has too many memoized helpers [18/5]                                                                                           
RSpec.describe "Api::V3::Internal::ShipmentSegments", type: :request, swagger_doc: "api/v3/internal/swagger.json" do ...                                                                                                                    
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                        
spec/requests/api/v3/internal/shipment_segments_spec.rb:48:13: C: RSpec/VariableName: Use snake_case for variable names.                                                                                                                    
        let(:"employee_ids[]") { driver_employee.id }                                                                                                                                                                                       
            ^^^^^^^^^^^^^^^^^                                                                                                                                                                                                               
spec/requests/api/v3/internal/shipment_segments_spec.rb:57:13: C: RSpec/VariableName: Use snake_case for variable names.                                                                                                                    
        let(:"employee_ids[]") { driver_employee.id }                                                                                                                                                                                       
            ^^^^^^^^^^^^^^^^^                                                                                                                                                                                                               
spec/requests/api/v3/internal/shipment_segments_spec.rb:66:13: C: RSpec/VariableName: Use snake_case for variable names.                                                                                                                    
        let(:"employee_ids[]") { driver_employee.id }                                                                                                                                                                                       
            ^^^^^^^^^^^^^^^^^                         
spec/requests/api/v3/internal/shipment_segments_spec.rb:265:13: C: RSpec/VariableName: Use snake_case for variable names.                                                                                                                   
        let(:"segment_ref_number[tracking]") { ref_number.tracking }                                                                                                                                                                        
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                                                                                                 
spec/requests/api/v3/internal/shipment_segments_spec.rb:275:13: C: RSpec/VariableName: Use snake_case for variable names.                                                                                                                   
        let(:"shipment_ref_number[tracking]") { ref_number.tracking }   
```