### PR TITLE
[~] Add more sensible rubocop configurations

### DIFF
--- a/rubocop-rspec.yml
+++ b/rubocop-rspec.yml
@@ -4,19 +4,30 @@ RSpec:
     - "spec/requests/**/*.rb"
 
 RSpec/NestedGroups:
-  Max: 5
+  Max: 6
 
-RSpec/MultipleExpectations:
-  Enabled: false
+RSpec/MessageSpies:
+  EnforcedStyle: receive
 
-RSpec/NamedSubject:
+# - Relaxed cops -
+RSpec/ExampleLength:
+  Max: 30
+
+RSpec/MultipleMemoizedHelpers:
+  Max: 10
+
+# - Disabled cops -
+RSpec/AnyInstance:
   Enabled: false
 
 RSpec/ContextWording:
   Enabled: false
 
-RSpec/AnyInstance:
+RSpec/MultipleExpectations:
   Enabled: false
 
 RSpec/MessageSpies:
+  Enabled: false
+
+RSpec/NamedSubject:
   Enabled: false


### PR DESCRIPTION
I've been with an eye on our pull requests/codebase and come up with these as more sensible configurations.

RSpec/NestedGroups: raised from 5 to 6.
RSpec/MessageSpies: prefer using `expect(obj).to receive(:method)` instead of `expect(obj).to have_received`.
RSpec/ExampleLength: raised from 5 to 30.
RSpec/MultipleMemoizedHelpers: allow up to 10 `let`s on an example (raised from 5).