### PR TITLE
[~] Set Naming/VariableNumber to snake_case

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -83,6 +83,9 @@ Metrics/MethodLength:
   Exclude:
     - spec/**/*.rb
 
+Naming/VariableNumber:
+  EnforcedStyle: snake_case
+
 Lint/AssignmentInCondition:
   Enabled: false
 


### PR DESCRIPTION
According to poll on Slack.

Prefered style:
```
# bad
:some_sym1
variable1 = 1

def some_method1; end

def some_method_1(arg1); end

# good
:some_sym_1
variable_1 = 1

def some_method_1; end

def some_method_1(arg_1); end
```