### PR TITLE
Change Style/FormatStringToken style to template

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -93,6 +93,9 @@ Style/Documentation:
   Exclude:
     - db/migrate/*
 
+Style/FormatStringToken:
+  EnforcedStyle: template
+
 # can I remove?
 Style/IfUnlessModifier:
   Enabled: false


### PR DESCRIPTION
`annotated` style (before):
```
# bad
format('%{greeting}', greeting: 'Hello')
format('%s', 'Hello')

# good
format('%<greeting>s', greeting: 'Hello')
```

`template` style (after):
```
# bad
format('%<greeting>s', greeting: 'Hello')
format('%s', 'Hello')

# good
format('%{greeting}', greeting: 'Hello')
```

#### Considerations:
* On `overhaul-backend` we already have 390+ offenses if configured using `annotated` (the default configuration), which lead rubocop to create an entry to `.rubocop_todo` editing its configuration to `template` (this change has no effect to `overhaul-backend`)
* On `notification-management-new` we already use `template` (configured on its .rubocop.yml) (this change has no effect to `notification-management-new`)