### PR TITLE
Improve rspec messages

### DIFF
--- a/rubocop-rspec.yml
+++ b/rubocop-rspec.yml
@@ -6,6 +6,9 @@ RSpec:
 RSpec/MessageSpies:
   EnforcedStyle: receive
 
+RSpec/ExampleWithoutDescription:
+  EnforcedStyle: single_line_only
+
 # - Relaxed cops -
 RSpec/ExampleLength:
   Max: 30

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -89,6 +89,11 @@ Naming/VariableNumber:
 Style/BlockComments:
   Enabled: false
 
+Style/BlockDelimiters:
+  IgnoredMethods:
+    - lambda
+    - proc
+
 Style/Documentation:
   Exclude:
     - db/migrate/*


### PR DESCRIPTION
# What does this PR do?

This PR aims to make examples more consistent and to enforce example messages presence *unless* the test is a one-liner.

Before this PR, those examples are fine:
```ruby
it {
  expect(something).to be_true
  expect(other_something).to be_true
}

it do
  expect(something).to be_true
  expect(other_something).to be_true
end
```

After this PR, those example have to be written as:
```ruby
# Curly brackets are not allowed for multi-line tests
# An example description is always required for multi-line tests
it "does something" do
  expect(something).to be_true
  expect(other_something).to be_true
end

# Note that one-liner tests are unchanged (curly brackets and description omission is fine)
it { expect(something).to be_true }
```