### PR TITLE
[~] Add style for StringLiteralsInInterpolation

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -118,3 +118,6 @@ Style/ParallelAssignment:
 
 Style/StringLiterals:
   EnforcedStyle: double_quotes
+
+Style/StringLiteralsInInterpolation:
+  EnforcedStyle: double_quotes


### PR DESCRIPTION
Change configuration on cop that checks for string literals inside interpolations
See: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/StringLiteralsInInterpolation

Before:
```ruby
# bad
"Hello #{%w[foo bar].join(", ")}"

# bad
<<~STR
  Hello #{%w[foo bar].join(", ")}
STR

# good
"Hello #{%w[foo bar].join(', ')}"

# good
<<~STR
  Hello #{%w[foo bar].join(', ')}
STR
```

After:
```ruby
# bad
"Hello #{%w[foo bar].join(', ')}"

# bad
<<~STR
  Hello #{%w[foo bar].join(', ')}
STR

# good
"Hello #{%w[foo bar].join(", ")}"

# good
<<~STR
  Hello #{%w[foo bar].join(", ")}
STR
```