### PR TITLE
Disable Naming/VariableNumber on routes.rb

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -84,6 +84,8 @@ Metrics/MethodLength:
 
 Naming/VariableNumber:
   EnforcedStyle: snake_case
+  Exclude:
+    - "**/config/routes.rb"
 
 # can I remove?
 Style/BlockComments:


### PR DESCRIPTION
Disable on routes definitions, otherwise it complains with:
```ruby
namespace :v2 do
  ...
end
```
