### PR TITLE
Disable Style/Documentation

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -97,8 +97,7 @@ Style/BlockDelimiters:
     - proc
 
 Style/Documentation:
-  Exclude:
-    - db/migrate/*
+  Enabled: false
 
 Style/FormatStringToken:
   EnforcedStyle: template


### PR DESCRIPTION
When updating rubocop_todo, noticed that a good amount of files were being added to exclude.
Based on some discussion, it would make sense to disable it for now.

# Jira Ticket
https://over-haul.atlassian.net/browse/P20-713