### PR TITLE
Change SymbolProc cop style to AllowMethodsWithArguments

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -127,3 +127,6 @@ Style/StringLiterals:
 
 Style/StringLiteralsInInterpolation:
   EnforcedStyle: double_quotes
+
+Style/SymbolProc:
+  AllowMethodsWithArguments: true


### PR DESCRIPTION
Before:
```ruby
# bad
['hello', 'world'].map { |s| s.upcase }

# bad
association :assets, blueprint: Vehicle, view: :full do |workflow|
  workflow.assets
end

# good
['hello', 'world'].map(&:upcase)

# good
association :assets, blueprint: Vehicle, view: :full, &:assets
```

After:
```ruby
# bad
['hello', 'world'].map { |s| s.upcase }

# good
association :assets, blueprint: Vehicle, view: :full do |workflow|
  workflow.assets
end

# good
['hello', 'world'].map(&:upcase)

# good
association :assets, blueprint: Vehicle, view: :full, &:assets
```