### PR TITLE
[P20-713] Add rubocop-rswag.yml to exclude the request tests at cop level

### DIFF
--- a/rubocop-rspec.yml
+++ b/rubocop-rspec.yml
@@ -1,7 +1,13 @@
+inherit_from: rubocop-rswag.yml
+
+# This option will tell rubocop to merge the exclude of multiple definitions.
+# Check: https://docs.rubocop.org/rubocop/configuration.html#merging-arrays-using-inherit_mode
+inherit_mode:
+  merge:
+    - Exclude
+
 RSpec:
   Enabled: true
-  Exclude:
-    - "spec/requests/**/*.rb" # rswag uses a custom DSL on top of RSpec
 
 RSpec/MessageSpies:
   EnforcedStyle: receive

--- a/rubocop-rswag.yml
+++ b/rubocop-rswag.yml
@@ -1,0 +1,344 @@
+# Why this file exist: Unfortunately, when "Exclude" is defined at department level, it's not merged with the ones
+# defined at cop level, the department are overridden by them, as described here
+# https://github.com/rubocop/rubocop/issues/9983.
+# Given the following config:
+# RSpec:
+#   Exclude:
+#   - "spec/requests/**/*.rb"
+#
+# And:
+# RSpec/LetSetup:
+#   Exclude:
+#     - "spec/api/controllers/create_spec.rb"
+#
+# The LetSetup exclusion will not be applied to /request/**/*.rb tests and RSpec/LetSetup offenses will be seen
+# for requests tests. So, this file ignores all rspec offenses for all requests tests at cop level, because the
+# exclude works well at this level.
+
+RSpec/AlignLeftLetBrace:
+  Exclude:
+    - "spec/requests/**/*.rb"
+
+RSpec/AlignRightLetBrace:
+  Exclude:
+    - "spec/requests/**/*.rb"
+
+RSpec/AnyInstance:
+  Exclude:
+    - "spec/requests/**/*.rb"
+
+RSpec/AroundBlock:
+  Exclude:
+    - "spec/requests/**/*.rb"
+
+RSpec/Be:
+  Exclude:
+    - "spec/requests/**/*.rb"
+
+RSpec/BeEql:
+  Exclude:
+    - "spec/requests/**/*.rb"
+
+RSpec/BeforeAfterAll:
+  Exclude:
+    - "spec/requests/**/*.rb"
+
+RSpec/ContextMethod:
+  Exclude:
+    - "spec/requests/**/*.rb"
+
+RSpec/ContextWording:
+  Exclude:
+    - "spec/requests/**/*.rb"
+
+RSpec/DescribeClass:
+  Exclude:
+    - "spec/requests/**/*.rb"
+
+RSpec/DescribeMethod:
+  Exclude:
+    - "spec/requests/**/*.rb"
+
+RSpec/DescribeSymbol:
+  Exclude:
+    - "spec/requests/**/*.rb"
+
+RSpec/DescribedClass:
+  Exclude:
+    - "spec/requests/**/*.rb"
+
+RSpec/DescribedClassModuleWrapping:
+  Exclude:
+    - "spec/requests/**/*.rb"
+
+RSpec/Dialect:
+  Exclude:
+    - "spec/requests/**/*.rb"
+
+RSpec/EmptyExampleGroup:
+  Exclude:
+    - "spec/requests/**/*.rb"
+
+RSpec/EmptyHook:
+  Exclude:
+    - "spec/requests/**/*.rb"
+
+RSpec/EmptyLineAfterExample:
+  Exclude:
+    - "spec/requests/**/*.rb"
+
+RSpec/EmptyLineAfterExampleGroup:
+  Exclude:
+    - "spec/requests/**/*.rb"
+
+RSpec/EmptyLineAfterFinalLet:
+  Exclude:
+    - "spec/requests/**/*.rb"
+
+RSpec/EmptyLineAfterHook:
+  Exclude:
+    - "spec/requests/**/*.rb"
+
+RSpec/EmptyLineAfterSubject:
+  Exclude:
+    - "spec/requests/**/*.rb"
+
+RSpec/ExampleLength:
+  Exclude:
+    - "spec/requests/**/*.rb"
+
+RSpec/ExampleWithoutDescription:
+  Exclude:
+    - "spec/requests/**/*.rb"
+
+RSpec/ExampleWording:
+  Exclude:
+    - "spec/requests/**/*.rb"
+
+RSpec/ExpectActual:
+  Exclude:
+    - "spec/requests/**/*.rb"
+
+RSpec/ExpectChange:
+  Exclude:
+    - "spec/requests/**/*.rb"
+
+RSpec/ExpectInHook:
+  Exclude:
+    - "spec/requests/**/*.rb"
+
+RSpec/ExpectOutput:
+  Exclude:
+    - "spec/requests/**/*.rb"
+
+RSpec/FilePath:
+  Exclude:
+    - "spec/requests/**/*.rb"
+
+RSpec/Focus:
+  Exclude:
+    - "spec/requests/**/*.rb"
+
+RSpec/HookArgument:
+  Exclude:
+    - "spec/requests/**/*.rb"
+
+RSpec/HooksBeforeExamples:
+  Exclude:
+    - "spec/requests/**/*.rb"
+
+RSpec/IdenticalEqualityAssertion:
+  Exclude:
+    - "spec/requests/**/*.rb"
+
+RSpec/ImplicitBlockExpectation:
+  Exclude:
+    - "spec/requests/**/*.rb"
+
+RSpec/ImplicitExpect:
+  Exclude:
+    - "spec/requests/**/*.rb"
+
+RSpec/ImplicitSubject:
+  Exclude:
+    - "spec/requests/**/*.rb"
+
+RSpec/InstanceSpy:
+  Exclude:
+    - "spec/requests/**/*.rb"
+
+RSpec/InstanceVariable:
+  Exclude:
+    - "spec/requests/**/*.rb"
+
+RSpec/ItBehavesLike:
+  Exclude:
+    - "spec/requests/**/*.rb"
+
+RSpec/IteratedExpectation:
+  Exclude:
+    - "spec/requests/**/*.rb"
+
+RSpec/LeadingSubject:
+  Exclude:
+    - "spec/requests/**/*.rb"
+
+RSpec/LeakyConstantDeclaration:
+  Exclude:
+    - "spec/requests/**/*.rb"
+
+RSpec/LetBeforeExamples:
+  Exclude:
+    - "spec/requests/**/*.rb"
+
+RSpec/LetSetup:
+  Exclude:
+    - "spec/requests/**/*.rb"
+
+RSpec/MessageChain:
+  Exclude:
+    - "spec/requests/**/*.rb"
+
+RSpec/MessageExpectation:
+  Exclude:
+    - "spec/requests/**/*.rb"
+
+RSpec/MessageSpies:
+  Exclude:
+    - "spec/requests/**/*.rb"
+
+RSpec/MissingExampleGroupArgument:
+  Exclude:
+    - "spec/requests/**/*.rb"
+
+RSpec/MultipleDescribes:
+  Exclude:
+    - "spec/requests/**/*.rb"
+
+RSpec/MultipleExpectations:
+  Exclude:
+    - "spec/requests/**/*.rb"
+
+RSpec/MultipleMemoizedHelpers:
+  Exclude:
+    - "spec/requests/**/*.rb"
+
+RSpec/MultipleSubjects:
+  Exclude:
+    - "spec/requests/**/*.rb"
+
+RSpec/NamedSubject:
+  Exclude:
+    - "spec/requests/**/*.rb"
+
+RSpec/NestedGroups:
+  Exclude:
+    - "spec/requests/**/*.rb"
+
+RSpec/NotToNot:
+  Exclude:
+    - "spec/requests/**/*.rb"
+
+RSpec/OverwritingSetup:
+  Exclude:
+    - "spec/requests/**/*.rb"
+
+RSpec/Pending:
+  Exclude:
+    - "spec/requests/**/*.rb"
+
+RSpec/PredicateMatcher:
+  Exclude:
+    - "spec/requests/**/*.rb"
+
+RSpec/ReceiveCounts:
+  Exclude:
+    - "spec/requests/**/*.rb"
+
+RSpec/ReceiveNever:
+  Exclude:
+    - "spec/requests/**/*.rb"
+
+RSpec/RepeatedDescription:
+  Exclude:
+    - "spec/requests/**/*.rb"
+
+RSpec/RepeatedExample:
+  Exclude:
+    - "spec/requests/**/*.rb"
+
+RSpec/RepeatedExampleGroupBody:
+  Exclude:
+    - "spec/requests/**/*.rb"
+
+RSpec/RepeatedExampleGroupDescription:
+  Exclude:
+    - "spec/requests/**/*.rb"
+
+RSpec/RepeatedIncludeExample:
+  Exclude:
+    - "spec/requests/**/*.rb"
+
+RSpec/ReturnFromStub:
+  Exclude:
+    - "spec/requests/**/*.rb"
+
+RSpec/ScatteredLet:
+  Exclude:
+    - "spec/requests/**/*.rb"
+
+RSpec/ScatteredSetup:
+  Exclude:
+    - "spec/requests/**/*.rb"
+
+RSpec/SharedContext:
+  Exclude:
+    - "spec/requests/**/*.rb"
+
+RSpec/SharedExamples:
+  Exclude:
+    - "spec/requests/**/*.rb"
+
+RSpec/SingleArgumentMessageChain:
+  Exclude:
+    - "spec/requests/**/*.rb"
+
+RSpec/StubbedMock:
+  Exclude:
+    - "spec/requests/**/*.rb"
+
+RSpec/SubjectStub:
+  Exclude:
+    - "spec/requests/**/*.rb"
+
+RSpec/UnspecifiedException:
+  Exclude:
+    - "spec/requests/**/*.rb"
+
+RSpec/VariableDefinition:
+  Exclude:
+    - "spec/requests/**/*.rb"
+
+RSpec/VariableName:
+  Exclude:
+    - "spec/requests/**/*.rb"
+
+RSpec/VerifiedDoubles:
+  Exclude:
+    - "spec/requests/**/*.rb"
+
+RSpec/VoidExpect:
+  Exclude:
+    - "spec/requests/**/*.rb"
+
+RSpec/Yield:
+  Exclude:
+    - "spec/requests/**/*.rb"
+
+RSpec/Rails/AvoidSetupHook:
+  Exclude:
+    - "spec/requests/**/*.rb"
+
+RSpec/Rails/HttpStatus:
+  Exclude:
+    - "spec/requests/**/*.rb"


### PR DESCRIPTION
The creation of `rubocop-rswag.yml` is a workaround to fix the issue of rubocop not merging excluded files of department with excluded at cop level.

Given the following config:
```yml
RSpec:
  Exclude:
    - "spec/requests/**/*.rb"
```
And:
```yml
RSpec/LetSetup:
  Exclude:
     - "spec/api/controllers/create_spec.rb"
```

The `LetSetup` exclusion will not be applied to `/request/**/*.rb` tests and `RSpec/LetSetup` offenses will be seen
for requests tests. So, this file ignores all rspec offenses for all requests tests at cop level, because the
Exclude merge works well at this level.

# Jira Ticket
https://over-haul.atlassian.net/browse/P20-713