### PR TITLE
Exclude public folder

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -5,6 +5,8 @@ inherit_mode:
 
 AllCops:
   NewCops: enable
+  Exclude:
+    - 'public/**/*'
 
 Bundler/DuplicatedGem:
   Enabled: false


### PR DESCRIPTION
While updating rubocop_todo, I've noticed that overhaul-backend was taking too long to start analysing the files.
The reason was because the `public/upload` had a huge number of subfolder and files.
I think this issue won't happen on CI, but could happen on dev environment. 

[OH BE] Not excluding public folder:
```
4210 files inspected, 63 offenses detected, 63 offenses auto-correctable
bundle exec rubocop --cache false  364.12s user 67.77s system 80% cpu 8:56.46 total
```
[OH BE] Excluding public folder:
```
4210 files inspected, 63 offenses detected, 63 offenses auto-correctable
bundle exec rubocop --cache false  241.48s user 4.54s system 90% cpu 4:33.30 total
```