### PR TITLE
Ignore BlockLength cop on Gemfile

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -68,6 +68,7 @@ Metrics/AbcSize:
 
 Metrics/BlockLength:
   Exclude:
+    - Gemfile
     - spec/**/*.rb
 
 Metrics/ClassLength:


### PR DESCRIPTION
Ignore BlockLength on Gemfile as it is not usual for some blocks to have many lines on the Gemfile