### PR TITLE
Update README - fix Gemfile instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Add to your Gemfile:
 ```ruby
 group :development
   gem 'rubocop', require: false
-  gem 'rubocop-overhaul', require: false
+  gem "rubocop-overhaul", github: "Over-haul/rubocop-overhaul", require: false
 end
 ```
 


### PR DESCRIPTION
Gem was not released, so it can't be installed unless via `github`.