### PR TITLE
[~] Disable Style/FetchEnvVar

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -133,3 +133,6 @@ Style/StringLiteralsInInterpolation:
 
 Style/SymbolProc:
   AllowMethodsWithArguments: true
+
+Style/FetchEnvVar:
+  Enabled: false


### PR DESCRIPTION
Currently rubocop throws error for fetching ENV variables like this:

**ENV["DD_SERVICE"]**

Demanding it to be changed to:

**ENV.fetch("DD_SERVICE")**

The problem is that changing to proposed style breaks GitHub CI becuase for some reason ENV vars are not fetched.
And that makes imposible merging PRs that touches files with such code (there is huge amount of this files in Events Gate)
Lets disable this rule for now and create spike for investigation.