### PR TITLE
Avoid usage of Ruby 3.1 shorthand hash definition

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -105,6 +105,9 @@ Style/Documentation:
 Style/FormatStringToken:
   EnforcedStyle: template
 
+Style/HashSyntax:
+  EnforcedShorthandSyntax: never
+
 # can I remove?
 Style/IfUnlessModifier:
   Enabled: false


### PR DESCRIPTION
Avoid usage of `{ x: }`

Some reasons:
```ruby
def destroy; puts "surprise"; end

{destroy:} # this will print "surprise"
```

```ruby
# consider
def build_user(name:)
  user = double id: 4, name:
  described_class.build_user(user)
end

# will be evaluated as:
def build_user(name:)
  user = double id: 4, name: described_class.build_user(nil)
end
```

This is all too confusing.