### PR TITLE
Opt out of Ruby 3.1 shorthand Hash syntax

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -11,6 +11,9 @@ AllCops:
 Bundler/DuplicatedGem:
   Enabled: false
 
+HashSyntax:
+  EnforcedShorthandSyntax: never
+
 Layout/ArgumentAlignment:
   EnforcedStyle: with_fixed_indentation
 

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -11,7 +11,7 @@ AllCops:
 Bundler/DuplicatedGem:
   Enabled: false
 
-HashSyntax:
+Style/HashSyntax:
   EnforcedShorthandSyntax: never
 
 Layout/ArgumentAlignment:


### PR DESCRIPTION
As discussed on Slack, we have no plans to adopt to the new Ruby 3.1 shorthand Hash syntax.

As the new syntax is a default on rubocop (see https://github.com/rubocop/rubocop/commit/d85a3c496e0077b2fafa4862937ff472015e094e), we have to opt out of it on this gem.