### PR TITLE
Revert "Opt out of Ruby 3.1 shorthand Hash syntax"

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -11,9 +11,6 @@ AllCops:
 Bundler/DuplicatedGem:
   Enabled: false
 
-Style/HashSyntax:
-  EnforcedShorthandSyntax: never
-
 Layout/ArgumentAlignment:
   EnforcedStyle: with_fixed_indentation
 


### PR DESCRIPTION
This is a duplicate of #30 

oh lord