### PR TITLE
Disable anonymous block syntax cop

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -85,6 +85,9 @@ Metrics/MethodLength:
   Max: 15
   CountAsOne: ['array', 'heredoc', 'hash']
 
+Naming/BlockForwarding:
+  Enabled: false
+
 Naming/VariableNumber:
   EnforcedStyle: snake_case
   Exclude:


### PR DESCRIPTION
Disabling the cop following to a Slack discussion on 22/Sep

---
Cop documentation: https://docs.rubocop.org/rubocop/cops_naming.html#namingblockforwarding