### PR TITLE
Fix config change on rubocop-rspec 2.24.0

### DIFF
--- a/rubocop-rswag.yml
+++ b/rubocop-rswag.yml
@@ -131,7 +131,11 @@ RSpec/ExpectOutput:
   Exclude:
     - "spec/requests/**/*.rb"
 
-RSpec/FilePath:
+RSpec/SpecFilePathFormat:
+  Exclude:
+    - "spec/requests/**/*.rb"
+
+RSpec/SpecFilePathSuffix:
   Exclude:
     - "spec/requests/**/*.rb"
 


### PR DESCRIPTION
[2.24.0](https://github.com/rubocop/rubocop-rspec/blob/master/CHANGELOG.md#2240-2023-09-08)
> Split RSpec/FilePath into RSpec/SpecFilePathSuffix and RSpec/SpecFilePathFormat. RSpec/FilePath cop is enabled by default, the two new cops are pending and need to be enabled explicitly. ([@ydah](https://github.com/ydah))

Fixes this error:
```
/home/runner/work/some-repo/some-repo/vendor/bundle/ruby/3.2.0/gems/rubocop-1.56.3/lib/rubocop/config_obsoletion.rb:43:in `reject_obsolete!': The `RSpec/FilePath` cop has been split into `RSpec/SpecFilePathFormat` and `RSpec/SpecFilePathSuffix`. (RuboCop::ValidationError)
(obsolete configuration found in vendor/bundle/ruby/3.2.0/bundler/gems/rubocop-overhaul-71d84a6db110/rubocop-rswag.yml, please update it)
```