### PR TITLE
[OK-34681] Add cop MutableReformDefaults

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -1,1 +1,7 @@
 ---
+Overhaul/MutableReformDefaults:
+  Description: Detect usage of mutable defaults within Reform objects defaults.
+  Enabled: true
+  Include:
+    app/concepts/**/*.rb
+  VersionAdded: '<<next>>'

--- a/lib/rubocop/cop/overhaul/mutable_reform_defaults.rb
+++ b/lib/rubocop/cop/overhaul/mutable_reform_defaults.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Overhaul
+      # Checks whether a Reform property default isn't a mutable object or
+      # a callable object.
+      # Implementation is somewhat based on the MutableConstant cop (strict
+      # mode).
+      #
+      # @example
+      #   # bad
+      #   class Create < Reform::Form
+      #     property :name, default: []
+      #   end
+      #
+      #   # good
+      #   class Create < Reform::Form
+      #     property :name, default: ->{ [] }
+      #   end
+      #
+      #   class Create < Reform::Form
+      #     property :name, default: :my_method
+      #
+      #     def my_method
+      #       []
+      #     end
+      #   end
+      #
+      class MutableReformDefaults < RuboCop::Cop::Cop
+        include FrozenStringLiteral
+
+        MSG = "Do not use mutable objects as Reform property defaults"
+
+        RESTRICT_ON_SEND = %i[property collection].freeze
+
+        def_node_matcher :operation_produces_immutable_object?, <<~PATTERN
+          {
+            (const _ _)
+            (send (const {nil? cbase} :Struct) :new ...)
+            (block (send (const {nil? cbase} :Struct) :new ...) ...)
+            (send _ :freeze)
+            (send {float int} {:+ :- :* :** :/ :% :<<} _)
+            (send _ {:+ :- :* :** :/ :%} {float int})
+            (send _ {:== :=== :!= :<= :>= :< :>} _)
+            (send (const {nil? cbase} :ENV) :[] _)
+            (or (send (const {nil? cbase} :ENV) :[] _) _)
+            (send _ {:count :length :size} ...)
+            (block (send _ {:count :length :size} ...) ...)
+          }
+        PATTERN
+
+        def_node_matcher :reform_mutable_property_default, <<~PATTERN
+          (send nil? /property|collection/
+           (sym _)
+           (hash
+             <(pair (sym :default) $_) ...>
+           ))
+        PATTERN
+
+        def on_send(node)
+          reform_mutable_property_default(node) do |value|
+            next if value.block_type?
+            next if value.immutable_literal?
+            next if operation_produces_immutable_object?(value)
+            next if frozen_string_literal?(value)
+
+            add_offense(value)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/overhaul_cops.rb
+++ b/lib/rubocop/cop/overhaul_cops.rb
@@ -1,3 +1,3 @@
 # frozen_string_literal: true
 
-# require cops here
+require_relative "overhaul/mutable_reform_defaults"

--- a/spec/rubocop/cop/overhaul/mutable_reform_defaults_spec.rb
+++ b/spec/rubocop/cop/overhaul/mutable_reform_defaults_spec.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Overhaul::MutableReformDefaults, :config do
+  let(:prefix) { nil }
+
+  shared_examples "mutable, non-callable default" do |o|
+    it "registers an offense for #{o}" do
+      expect_offense([prefix, <<~RUBY].compact.join("\n"), o: o)
+        property :something, default: %{o}
+                                      ^{o} Do not use mutable objects as Reform property defaults
+      RUBY
+
+      expect_offense([prefix, <<~RUBY].compact.join("\n"), o: o)
+        property :something, default: %{o}, populator: ->(fragment:, **) { self.name = "John" }
+                                      ^{o} Do not use mutable objects as Reform property defaults
+      RUBY
+
+      expect_offense([prefix, <<~RUBY].compact.join("\n"), o: o)
+        property :something, populator: ->(fragment:, **) { self.name = "John" }, default: %{o}
+                                                                                           ^{o} Do not use mutable objects as Reform property defaults
+      RUBY
+    end
+  end
+
+  shared_examples "immutable or callable default" do |o|
+    it "allows #{o} to be registed as a default" do
+      source = [prefix, "property :something, default: #{o}"].compact.join("\n")
+      expect_no_offenses(source)
+
+      source = [
+        prefix,
+        "property :something, default: #{o}, populator: ->(fragment:, **) { self.name = 'John' }"
+      ].compact.join("\n")
+      expect_no_offenses(source)
+
+      source = [
+        prefix,
+        "property :something, populator: ->(fragment:, **) { self.name = 'John' }, default: #{o}"
+      ].compact.join("\n")
+      expect_no_offenses(source)
+    end
+  end
+
+  context "when the frozen string literal comment is missing" do
+    it_behaves_like "mutable, non-callable default", '"#{a}"' # rubocop:disable Lint/InterpolationCheck
+    it_behaves_like "mutable, non-callable default", "'some string'"
+    it_behaves_like "immutable or callable default", "'some string'.freeze"
+  end
+
+  context "when the frozen string literal comment is true" do
+    let(:prefix) { "# frozen_string_literal: true" }
+
+    context "and ruby > 3.0", :ruby30 do
+      it_behaves_like "mutable, non-callable default", '"#{a}"' # rubocop:disable Lint/InterpolationCheck
+    end
+
+    context "and ruby < 3.0", :ruby27 do
+      it_behaves_like "immutable or callable default", '"#{a}"' # rubocop:disable Lint/InterpolationCheck
+    end
+
+    it_behaves_like "immutable or callable default", "'some string'"
+  end
+
+  it_behaves_like "immutable or callable default", "true"
+  it_behaves_like "immutable or callable default", "false"
+  it_behaves_like "immutable or callable default", "nil"
+  it_behaves_like "immutable or callable default", "0"
+  it_behaves_like "immutable or callable default", "0.5"
+  it_behaves_like "immutable or callable default", "a + 5"
+  it_behaves_like "immutable or callable default", "a + 5.0"
+  it_behaves_like "immutable or callable default", "5 + 5.0"
+  it_behaves_like "immutable or callable default", "5.0 + 5.0"
+  it_behaves_like "immutable or callable default", "5.0 + 5"
+  it_behaves_like "immutable or callable default", "5.0 + a"
+  it_behaves_like "immutable or callable default", "[1, 2, 3].freeze"
+  it_behaves_like "immutable or callable default", "Namespace::SOME_CONST"
+  it_behaves_like "immutable or callable default", ":some_method"
+  it_behaves_like "immutable or callable default", "->{ [] }"
+  it_behaves_like "immutable or callable default", "Proc.new { [] }"
+  it_behaves_like "immutable or callable default", "proc { [] }"
+  it_behaves_like "immutable or callable default", "lambda { [] }"
+  it_behaves_like "immutable or callable default", "ENV['something']"
+
+  it_behaves_like "mutable, non-callable default", "[]"
+  it_behaves_like "mutable, non-callable default", "{}"
+  it_behaves_like "mutable, non-callable default", "a"
+  it_behaves_like "mutable, non-callable default", "MyObject.new"
+end


### PR DESCRIPTION
Add new cop that checks whether a Reform property default isn't a mutable object or a callable object. Implementation is somewhat based on the [MutableConstant](https://docs.rubocop.org/rubocop/cops_style.html#stylemutableconstant) cop (strict mode).

```ruby
# bad
class Create < Reform::Form
  property :name, default: []
end

# bad
class Create < Reform::Form
  property :name, default: {}
end

# bad
class Create < Reform::Form
  property :name, default: "foo"
end

# good
# frozen_string_literal: true
class Create < Reform::Form
  property :name, default: "foo"
end

# good
class Create < Reform::Form
  property :is_good, default: true
end

# good
class Create < Reform::Form
  property :name, default: ->{ [] }
end

# good
class Create < Reform::Form
  property :name, default: :my_method

  def my_method
    []
  end
end
```