### PR TITLE
Fix AssignmentInsteadComparison for setter methods

### DIFF
--- a/lib/rubocop/cop/overhaul/assignment_instead_of_comparison.rb
+++ b/lib/rubocop/cop/overhaul/assignment_instead_of_comparison.rb
@@ -24,7 +24,7 @@ module RuboCop
           :sort, :sort_by # sort
         ].freeze
 
-        # @!method search_method_calls?(node)
+        # @!method search_method_calls(node)
         def_node_matcher :search_method_calls, <<~PATTERN
           (block
             (call _ /#{RESTRICT_ENUM_METHODS.join("|")}/)
@@ -37,11 +37,16 @@ module RuboCop
           search_method_calls(node) do |value|
             value = value.first
             block_return_operation = value.begin_type? ? value.children.last : value
-            next unless block_return_operation.lvasgn_type?
 
-            add_offense(block_return_operation)
+            add_offense(block_return_operation) if assignment?(block_return_operation)
           end
         end
+
+        private
+
+          def assignment?(node)
+            node.lvasgn_type? || (node.call_type? && node.assignment_method?)
+          end
       end
     end
   end

--- a/lib/rubocop/overhaul/version.rb
+++ b/lib/rubocop/overhaul/version.rb
@@ -2,6 +2,6 @@
 
 module RuboCop
   module Overhaul
-    VERSION = "0.0.1"
+    VERSION = "0.1.0"
   end
 end

--- a/spec/rubocop/cop/overhaul/assignment_instead_of_comparison_spec.rb
+++ b/spec/rubocop/cop/overhaul/assignment_instead_of_comparison_spec.rb
@@ -25,9 +25,11 @@ RSpec.describe RuboCop::Cop::Overhaul::AssignmentInsteadOfComparison, :config do
     context "when method is #{method}" do
       let(:method) { method }
 
+      it_behaves_like "block returning assignment", "x.type = 3"
       it_behaves_like "block returning assignment", "x = 3"
       it_behaves_like "block returning assignment", "var = 10; x = 3"
 
+      it_behaves_like "block returning comparison", "x.type == 3"
       it_behaves_like "block returning comparison", "x == 3"
       it_behaves_like "block returning comparison", "x = 3; a"
     end


### PR DESCRIPTION
Also work on setter methods:
```ruby
# bad
my_arr.select { |x| x.type = 3 }

# good
my_arr.select { |x| x.type == 3 }
```
