### PR TITLE
[OK-38947] New cop: Overhaul/SemanticLoggerContract cop

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -9,3 +9,7 @@ Overhaul/AssignmentInsteadOfComparison:
   Description: Detect enumerable comparison blocks returning an assignment.
   Enabled: true
   VersionAdded: '0.0.1'
+Overhaul/SemanticLoggerContract:
+  Description: Detect logger usage incompatible with Semantic Logger
+  Enabled: true
+  VersionAdded: '0.0.1'

--- a/lib/rubocop/cop/overhaul/semantic_logger_contract.rb
+++ b/lib/rubocop/cop/overhaul/semantic_logger_contract.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Overhaul
+      # Checks logger usage that is incompatible with SemanticLogger contract.
+      # See: https://github.com/reidmorrison/semantic_logger/issues/250
+      #
+      # @example
+      #
+      # # bad:
+      # logger.info(message: "foo", payload: {}, error: StandardError.new)
+      #
+      # # good:
+      # logger.info(message: "foo", error: StandardError.new)
+      # logger.info(message: "foo", payload: {}, exception: StandardError.new)
+      # logger.info("foo", {}, StandardError.new)
+      class SemanticLoggerContract < RuboCop::Cop::Cop
+        MSG = "Logger usage incompatible with SemanticLogger. `payload` cannot be used along with arbitrary keywords."
+
+        RESTRICT_ON_SEND = %i[error warn info debug fatal].freeze
+
+        # @see
+        # https://github.com/reidmorrison/semantic_logger/blob/v4.14.0/lib/semantic_logger/log.rb#L51-L54
+        SEMANTIC_LOGGER_ALLOWED_KEYWORDS = %i[
+          message exception backtrace exception
+          duration min_duration payload
+          log_exception on_exception_level
+          metric metric_amount dimensions
+        ].to_set.freeze
+
+        def_node_matcher :logger_call, <<~PATTERN
+          (send
+           _ _
+           (hash $...))
+        PATTERN
+
+        def on_send(node)
+          logger_call(node) do |pairs|
+            return unless pairs.any? { |pair| pair.key.value == :payload }
+
+            pairs
+              .reject { |pair| SEMANTIC_LOGGER_ALLOWED_KEYWORDS.include?(pair.key.value) }
+              .each { |pair| add_offense(pair) }
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/overhaul_cops.rb
+++ b/lib/rubocop/cop/overhaul_cops.rb
@@ -2,3 +2,4 @@
 
 require_relative "overhaul/mutable_reform_defaults"
 require_relative "overhaul/assignment_instead_of_comparison"
+require_relative "overhaul/semantic_logger_contract"

--- a/spec/rubocop/cop/overhaul/semantic_logger_contract_spec.rb
+++ b/spec/rubocop/cop/overhaul/semantic_logger_contract_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Overhaul::SemanticLoggerContract, :config do
+  described_class::RESTRICT_ON_SEND.each do |method|
+    context "when using `##{method}`" do
+      let(:method) { method }
+
+      it "flags a logger usage incompatible with SemanticLogger" do
+        expect_offense(<<~RUBY, method: method)
+          logger.%{method}(message: "foo", payload: {}, error: e)
+                 _{method}                              ^^^^^^^^ Logger usage incompatible with[...]
+        RUBY
+      end
+
+      it "does not flag logger usage compatible with SemanticLogger" do
+        expect_no_offenses(<<~RUBY)
+          logger.#{method}(message: "foo", payload: {}, exception: e)
+          logger.#{method}("foo", {}, e)
+          logger.#{method}("foo", error: e)
+          logger.#{method}(message: "foo", error: e)
+        RUBY
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Overhaul/SemanticLoggerContract
Checks for a logger usage that is compatible with SemanticLogger. For context, using the `payload:` keyword along with non-supported keywords raises an error in runtime in SemanticLogger, see: https://github.com/reidmorrison/semantic_logger/discussions/265

```ruby
# bad:
logger.info(message: "foo", payload: {}, error: StandardError.new)

# good:
logger.info(message: "foo", error: StandardError.new)
logger.info(message: "foo", payload: {}, exception: StandardError.new)
logger.info("foo", {}, StandardError.new)
```

(note: although enabled by default, this cop is specific to [SemanticLogger](https://github.com/reidmorrison/semantic_logger/))