### PR TITLE
[OK-42561] CODEOWNERS: use `overhaul-ruby-dev-team` instead of `be-core`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,6 @@
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence,
-# @Over-haul/be-core will be requested for
+# @Over-haul/overhaul-ruby-dev-team will be requested for
 # review when someone opens a pull request.
 
-* @Over-haul/be-core @Drowze @ybregey
+@Over-haul/overhaul-ruby-dev-team @Drowze @ybregey


### PR DESCRIPTION
As discussed in the last retro, setup CODEOWNERS such as:
- for sensitive bits of architecture (changes to  database, http routes & kafka consumers), require a code review from [be-core](https://github.com/orgs/Over-haul/teams/be-core)
- for everything else, require a code view from any ruby developer in [overhaul-ruby-dev-team](https://github.com/orgs/Over-haul/teams/overhaul-ruby-dev-team)