### PR TITLE
[~] Disable `Rails/BulkChangeTable` as it conflicts with strong_migrations

### DIFF
--- a/oh_defaults/rubocop-rails.yml
+++ b/oh_defaults/rubocop-rails.yml
@@ -12,3 +12,7 @@ Rails/UnknownEnv:
     - prod
     - test
     - production
+
+# conflicts with strong_migrations gem
+Rails/BulkChangeTable:
+  Enabled: false


### PR DESCRIPTION
It conflicts with strong_migrations suggestions. For instance, the
following code reports an offense:
```ruby
add_column :foo, :bar, :string
add_column :foo, :baz, :string
```

The above is suggested to be written instead as:
```ruby
change_table :foo, bulk: true do |t|
  t.string :bar
  t.string :baz
end
```

Which in turn is not supported with strong_migrations and raises an
error when trying to execute the migration:
https://github.com/ankane/strong_migrations?tab=readme-ov-file#assuring-safety
> Certain methods like execute and **change_table** cannot be inspected and
> are prevented from running by default. Make sure what you’re doing is
> really safe and use this pattern.
