### PR TITLE
Relax config for rubocop-rspec and add workaround for factory_bot false positive

### DIFF
--- a/lib/rubocop/overhaul/version.rb
+++ b/lib/rubocop/overhaul/version.rb
@@ -2,6 +2,6 @@
 
 module RuboCop
   module Overhaul
-    VERSION = "0.3.1"
+    VERSION = "0.3.2"
   end
 end

--- a/oh_defaults/rubocop-factory_bot.yml
+++ b/oh_defaults/rubocop-factory_bot.yml
@@ -1,2 +1,4 @@
 FactoryBot/AssociationStyle:
   EnforcedStyle: explicit
+  NonImplicitAssociationMethodNames:
+    - trait # workaround false positive on empty traits

--- a/oh_defaults/rubocop-rspec.yml
+++ b/oh_defaults/rubocop-rspec.yml
@@ -22,6 +22,10 @@ RSpec/ExampleLength:
 RSpec/NestedGroups:
   Max: 6
 
+RSpec/DescribedClass:
+  Exclude:
+    - spec/models/**/*
+
 # - Disabled cops -
 RSpec/AnyInstance:
   Enabled: false


### PR DESCRIPTION
# Description

* Relax `RSpec/DescribedClass`, disabling it in spec/models/**/*
  * as agreed in Slack, allowing usage of explicit class name should make testing model scopes less of a hassle
* Workaround for FactoryBot/AssociationStyle false positive
    The following code was raising a warning where it shouldn't:
    ```ruby
    FactoryBot.define do
      factory :user do
        name { "John" }

        # warn raised on this trait call - rubocop mistakenly
        # consider "trait" as an implicit association
        trait :john
      end
    end
    ```

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
