### PR TITLE
[~] AssignmentInsteadOfComparison: fix error on empty blocks

### DIFF
--- a/lib/rubocop/cop/overhaul/assignment_instead_of_comparison.rb
+++ b/lib/rubocop/cop/overhaul/assignment_instead_of_comparison.rb
@@ -34,6 +34,8 @@ module RuboCop
         PATTERN
 
         def on_block(node)
+          return if node.body.nil? # empty block
+
           search_method_calls(node) do |value|
             value = value.first
             block_return_operation = value.begin_type? ? value.children.last : value

--- a/spec/rubocop/cop/overhaul/assignment_instead_of_comparison_spec.rb
+++ b/spec/rubocop/cop/overhaul/assignment_instead_of_comparison_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe RuboCop::Cop::Overhaul::AssignmentInsteadOfComparison, :config do
       it_behaves_like "block returning comparison", "x.type == 3"
       it_behaves_like "block returning comparison", "x == 3"
       it_behaves_like "block returning comparison", "x = 3; a"
+      it_behaves_like "block returning comparison", "" # empty block
     end
   end
 end


### PR DESCRIPTION
# Description

Reproducing the error:
```bash
$ echo '[1,2,3].select {}' | bundle exec rubocop --stdin test.rb
Inspecting 1 file
An error occurred while Overhaul/AssignmentInsteadOfComparison cop was inspecting /Users/Drowze/test.rb:1:0.
Errors are usually caused by RuboCop bugs.
Please, update to the latest RuboCop version if not already in use, and report a bug if the issue still occurs on this version.
https://github.com/rubocop/rubocop/issues
```

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
